### PR TITLE
Minimalist Git & Github support via CLI 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,13 @@ manual_test/
 
 # other local dev info
 .vscode/
+.history/
 
 # Mac OS-specific storage files
 .DS_Store
+Icon?
+Icon
+Icon[\r]
 
 # vim
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ Icon?
 Icon
 Icon[\r]
 
+# ruff
+.ruff_cache/
+
 # vim
 *.swp
 *.swo

--- a/ccds-help.json
+++ b/ccds-help.json
@@ -277,5 +277,35 @@
                 } 
             }
         ]
+    },
+    {
+        "field": "version_control",
+        "help": {
+            "description": "What kind of version control system (vcs) and repository host to use.",
+            "more_information": ""
+        },
+        "choices": [
+            {
+                "choice": "none",
+                "help": {
+                    "description": "No version control.",
+                    "more_information": ""
+                } 
+            },
+            {
+                "choice": "git (local)",
+                "help": {
+                    "description": "Initialize a git repository locally.",
+                    "more_information": ""
+                } 
+            },
+            {
+                "choice": "git (github)",
+                "help": {
+                    "description": "Initialize a git repository locally and upload to GitHub",
+                    "more_information": ""
+                } 
+            }
+        ]
     }
 ]

--- a/ccds-help.json
+++ b/ccds-help.json
@@ -295,15 +295,22 @@
             {
                 "choice": "git (local)",
                 "help": {
-                    "description": "Initialize a git repository locally.",
-                    "more_information": ""
+                    "description": "Initialize project as a local git repository.",
+                    "more_information": "[Git CLI](https://git-scm.com/downloads) Required"
                 } 
             },
             {
-                "choice": "git (github)",
+                "choice": "git (github private)",
                 "help": {
-                    "description": "Initialize a git repository locally and upload to GitHub",
-                    "more_information": ""
+                    "description": "Initialize project and upload to GitHub as a **private** repo.",
+                    "more_information": "[Git CLI](https://git-scm.com/downloads) + [GitHub CLI](https://cli.github.com/) & [Auth](https://cli.github.com/manual/gh_auth_login) Required"
+                } 
+            },
+            {
+                "choice": "git (github public)",
+                "help": {
+                    "description": "Initialize project and upload to GitHub as a **public** repo.",
+                    "more_information": "[Git CLI](https://git-scm.com/downloads) + [GitHub CLI](https://cli.github.com/) & [Auth](https://cli.github.com/manual/gh_auth_login) Required"
                 } 
             }
         ]

--- a/ccds.json
+++ b/ccds.json
@@ -32,6 +32,7 @@
     "version_control": [
         "none",
         "git (local)",
-        "git (github)"
+        "git (github private)",
+        "git (github public)"
     ]
 }

--- a/ccds.json
+++ b/ccds.json
@@ -30,8 +30,8 @@
     "docs": ["mkdocs", "none"],
     "include_code_scaffold": ["Yes", "No"],
     "version_control": [
-        "git (local)",
         "none",
+        "git (local)",
         "git (github)"
     ]
 }

--- a/ccds.json
+++ b/ccds.json
@@ -30,8 +30,8 @@
     "docs": ["mkdocs", "none"],
     "include_code_scaffold": ["Yes", "No"],
     "version_control": [
+        "git (local)",
         "none",
-        "git (github)",
-        "git (local)"
+        "git (github)"
     ]
 }

--- a/ccds.json
+++ b/ccds.json
@@ -31,7 +31,7 @@
     "include_code_scaffold": ["Yes", "No"],
     "version_control": [
         "none",
-        "git (local)",
-        "git (github)"
+        "git (github)",
+        "git (local)"
     ]
 }

--- a/ccds.json
+++ b/ccds.json
@@ -28,5 +28,10 @@
     ],
     "open_source_license": ["No license file", "MIT", "BSD-3-Clause"],
     "docs": ["mkdocs", "none"],
-    "include_code_scaffold": ["Yes", "No"]
+    "include_code_scaffold": ["Yes", "No"],
+    "version_control": [
+        "none",
+        "git (local)",
+        "git (github)"
+    ]
 }

--- a/ccds/hook_utils/configure_vcs.py
+++ b/ccds/hook_utils/configure_vcs.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Union
 
 # ---------------------------------------------------------------------------- #
 #                                      Git                                     #
@@ -9,7 +9,7 @@ from typing import Literal
 
 
 def init_local_git_repo(
-    directory: str | Path, _make_initial_commit: bool = True
+    directory: Union[str, Path], _make_initial_commit: bool = True
 ) -> bool:
     """
     Initialize a local git repository without any GitHub integration.
@@ -63,7 +63,7 @@ def _check_git_cli_installed() -> bool:
 
 
 def configure_github_repo(
-    directory: str | Path,
+    directory: Union[str, Path],
     repo_name: str,
     visibility: Literal["private", "public"] = "private",
 ) -> bool:

--- a/ccds/hook_utils/configure_vcs.py
+++ b/ccds/hook_utils/configure_vcs.py
@@ -194,3 +194,31 @@ def _set_branch_protection(username: str, repo_name: str, branch: str) -> None:
         f"-f required_pull_request_reviews='{protection_data['required_pull_request_reviews']}' "
         f"-f restrictions={protection_data['restrictions']}"
     )
+
+
+def init_local_git_repo(directory: str | Path) -> bool:
+    """
+    Initialize a local git repository without any GitHub integration.
+    
+    Args:
+        directory: Directory where the repository will be created
+        
+    Returns:
+        bool: True if initialization was successful, False otherwise
+    """
+    try:
+        directory = Path(directory)
+        if not directory.is_dir():
+            raise ValueError(f"Directory '{directory}' does not exist.")
+            
+        os.chdir(directory)
+        
+        if not (directory / ".git").is_dir():
+            _run_git_command("init")
+            _run_git_command("add .")
+            _run_git_command("commit -m 'Initial commit'")
+            
+        return True
+    except Exception as e:
+        print(f"Error during repository initialization: {e}")
+        return False

--- a/ccds/hook_utils/configure_vcs.py
+++ b/ccds/hook_utils/configure_vcs.py
@@ -65,7 +65,7 @@ def _check_git_cli_installed() -> bool:
 def configure_github_repo(
     directory: str | Path,
     repo_name: str,
-    visibility: Literal["private", "public"] = "private"
+    visibility: Literal["private", "public"] = "private",
 ) -> bool:
     """
     Configure a Git repository locally and optionally on GitHub with specified branch protections.
@@ -85,11 +85,15 @@ def configure_github_repo(
     try:
         subprocess.run("gh auth status", shell=True, check=True, capture_output=True)
     except subprocess.CalledProcessError:
-        raise RuntimeError("GitHub CLI not authenticated. Please run `gh auth login` and try again.")
-    
+        raise RuntimeError(
+            "GitHub CLI not authenticated. Please run `gh auth login` and try again."
+        )
+
     try:
         # GitHub operations
-        github_username = _gh("api user -q .login", capture_output=True, text=True).stdout.strip()
+        github_username = _gh(
+            "api user -q .login", capture_output=True, text=True
+        ).stdout.strip()
 
         # Create or update GitHub repository
         if not _github_repo_exists(github_username, repo_name):
@@ -125,10 +129,13 @@ def _gh(command: str, **kwargs) -> subprocess.CompletedProcess:
     """Run a GitHub CLI command and return the result."""
     return subprocess.run(f"gh {command}", shell=True, check=True, **kwargs)
 
+
 def _get_gh_remote_url(github_username: str, repo_name: str) -> Literal["https", "ssh"]:
     """Returns whether the github protocol is https or ssh from user's config"""
     try:
-        protocol = _gh("config get git_protocol", capture_output=True, text=True).stdout.strip()
+        protocol = _gh(
+            "config get git_protocol", capture_output=True, text=True
+        ).stdout.strip()
         if protocol == "ssh":
             return f"git@github.com:{github_username}/{repo_name}.git"
         elif protocol == "https":

--- a/ccds/hook_utils/configure_vcs.py
+++ b/ccds/hook_utils/configure_vcs.py
@@ -10,12 +10,13 @@ from typing import Literal
 # ---------------------------------------------------------------------------- #
 
 
-def init_local_git_repo(directory: str | Path) -> bool:
+def init_local_git_repo(directory: str | Path, _make_initial_commit: bool = True) -> bool:
     """
     Initialize a local git repository without any GitHub integration.
     
     Args:
         directory: Directory where the repository will be created
+        _make_initial_commit: Whether to make initial commit (for testing)
         
     Returns:
         bool: True if initialization was successful, False otherwise
@@ -32,8 +33,9 @@ def init_local_git_repo(directory: str | Path) -> bool:
         
         if not (directory / ".git").is_dir():
             _git("init")
-            _git("add .")
-            _git("commit -m 'Initial commit'")
+            if _make_initial_commit:
+                _git("add .")
+                _git("commit -m 'Initial commit'")
             
         return True
     except Exception as e:

--- a/ccds/hook_utils/configure_vcs.py
+++ b/ccds/hook_utils/configure_vcs.py
@@ -144,23 +144,6 @@ def _get_gh_remote_url(github_username: str, repo_name: str) -> Literal["https",
         # Default to https if not set
         return "https"
 
-def _tag_exists(tag: str) -> bool:
-    """Check if a git tag exists."""
-    try:
-        _git(f"rev-parse {tag}", capture_output=True)
-        return True
-    except subprocess.CalledProcessError:
-        return False
-
-
-def _branch_exists(branch: str) -> bool:
-    """Check if a git branch exists."""
-    try:
-        _git(f"rev-parse --verify {branch}", capture_output=True)
-        return True
-    except subprocess.CalledProcessError:
-        return False
-
 
 def _github_repo_exists(username: str, repo_name: str) -> bool:
     """Check if a GitHub repository exists."""
@@ -169,30 +152,3 @@ def _github_repo_exists(username: str, repo_name: str) -> bool:
         return True
     except subprocess.CalledProcessError:
         return False
-
-
-def _is_repo_public(username: str, repo_name: str) -> bool:
-    """Check if a GitHub repository is public."""
-    result = _gh(
-        f"api repos/{username}/{repo_name} -q .private", capture_output=True, text=True
-    )
-    return result.stdout.strip() == "false"
-
-
-def _set_branch_protection(username: str, repo_name: str, branch: str) -> None:
-    """Set branch protection rules. Only works with enterprise(?)."""
-    protection_data = {
-        "required_status_checks": {"strict": True, "contexts": []},
-        "enforce_admins": True,
-        "required_pull_request_reviews": {"required_approving_review_count": 1},
-        "restrictions": None,
-    }
-
-    _gh(
-        f"api repos/{username}/{repo_name}/branches/{branch}/protection "
-        "-X PUT -H 'Accept: application/vnd.github.v3+json' "
-        f"-f required_status_checks='{protection_data['required_status_checks']}' "
-        f"-f enforce_admins={protection_data['enforce_admins']} "
-        f"-f required_pull_request_reviews='{protection_data['required_pull_request_reviews']}' "
-        f"-f restrictions={protection_data['restrictions']}"
-    )

--- a/ccds/hook_utils/configure_vcs.py
+++ b/ccds/hook_utils/configure_vcs.py
@@ -1,0 +1,196 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import Literal
+
+# TODO: Refactor this entirely, maybe use github module or something.
+
+
+def configure_github_repo(
+    directory: str | Path,
+    repo_name: str,
+    protection_type: Literal["none", "main", "main_and_dev"],
+    no_github: bool = False,
+) -> bool:
+    """
+    Configure a Git repository locally and optionally on GitHub with specified branch protections.
+
+    Args:
+        directory: Directory where the repository will be created or updated
+        repo_name: Name of the repository
+        protection_type: Type of branch protection to apply:
+            - "none": No branch protection
+            - "main": Protected main branch
+            - "main_and_dev": Protected main and dev branches
+        no_github: If True, skips GitHub operations and only sets up local repository
+
+    Returns:
+        bool: True if configuration was successful, False otherwise
+    """
+    try:
+        directory = Path(directory)
+
+        # Validate inputs
+        if not directory.is_dir():
+            raise ValueError(f"Directory '{directory}' does not exist.")
+
+        if not repo_name.replace("-", "").replace("_", "").isalnum():
+            raise ValueError(
+                "Invalid repository name. Use only letters, numbers, underscores, and hyphens."
+            )
+
+        # Check for gh CLI if needed
+        if not no_github:
+            if not _check_gh_cli():
+                raise RuntimeError(
+                    "gh CLI is required but not installed or not authenticated. "
+                    "Use no_github=True to skip GitHub operations."
+                )
+
+        # Change to specified directory
+        os.chdir(directory)
+
+        # Initialize repository if needed
+        if not (directory / ".git").is_dir():
+            _run_git_command("init")
+
+        # Add and commit changes if needed
+        if _run_git_command("status --porcelain", capture_output=True).stdout:
+            _run_git_command("add .")
+            _run_git_command("commit -m 'Initial commit'")
+
+        # Add semantic versioning tag if it doesn't exist
+        if not _tag_exists("v0.1.0"):
+            _run_git_command("tag -a v0.1.0 -m 'Initial version'")
+
+        # Create dev branch if needed
+        if protection_type == "main_and_dev":
+            if not _branch_exists("dev"):
+                _run_git_command("branch dev")
+
+        # GitHub operations
+        if not no_github:
+            github_username = _get_github_username()
+
+            # Create or update GitHub repository
+            if not _github_repo_exists(github_username, repo_name):
+                _run_gh_command(
+                    f"repo create {repo_name} --private --source=. --remote=origin --push"
+                )
+            else:
+                remote_url = f"git@github.com:{github_username}/{repo_name}.git"
+                try:
+                    _run_git_command(f"remote set-url origin {remote_url}")
+                except subprocess.CalledProcessError:
+                    _run_git_command(f"remote add origin {remote_url}")
+
+            # Push branches and tags
+            _run_git_command("push -u origin main")
+            _run_git_command("push --tags")
+
+            if _branch_exists("dev"):
+                _run_git_command("push -u origin dev")
+
+            # Set branch protections if repository is public
+            is_public = _is_repo_public(github_username, repo_name)
+            if is_public:
+                if protection_type in ["main", "main_and_dev"]:
+                    _set_branch_protection(github_username, repo_name, "main")
+                if protection_type == "main_and_dev":
+                    _set_branch_protection(github_username, repo_name, "dev")
+                print("Branch protections set successfully.")
+            else:
+                print(
+                    "Warning: Branch protections can only be set for public repositories "
+                    "or with a GitHub Pro account."
+                )
+
+            print("Repository configuration complete on GitHub!")
+        else:
+            print("Local repository configuration complete!")
+
+        return True
+
+    except Exception as e:
+        print(f"Error during repository configuration: {e}")
+        return False
+
+
+def _run_git_command(command: str, **kwargs) -> subprocess.CompletedProcess:
+    """Run a git command and return the result."""
+    return subprocess.run(f"git {command}", shell=True, check=True, **kwargs)
+
+
+def _run_gh_command(command: str, **kwargs) -> subprocess.CompletedProcess:
+    """Run a GitHub CLI command and return the result."""
+    return subprocess.run(f"gh {command}", shell=True, check=True, **kwargs)
+
+
+def _check_gh_cli() -> bool:
+    """Check if gh CLI is installed and authenticated."""
+    try:
+        subprocess.run("gh --version", shell=True, check=True, capture_output=True)
+        subprocess.run("gh auth status", shell=True, check=True, capture_output=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _tag_exists(tag: str) -> bool:
+    """Check if a git tag exists."""
+    try:
+        _run_git_command(f"rev-parse {tag}", capture_output=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _branch_exists(branch: str) -> bool:
+    """Check if a git branch exists."""
+    try:
+        _run_git_command(f"rev-parse --verify {branch}", capture_output=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _get_github_username() -> str:
+    """Get the authenticated GitHub username."""
+    result = _run_gh_command("api user -q .login", capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _github_repo_exists(username: str, repo_name: str) -> bool:
+    """Check if a GitHub repository exists."""
+    try:
+        _run_gh_command(f"repo view {username}/{repo_name}", capture_output=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _is_repo_public(username: str, repo_name: str) -> bool:
+    """Check if a GitHub repository is public."""
+    result = _run_gh_command(
+        f"api repos/{username}/{repo_name} -q .private", capture_output=True, text=True
+    )
+    return result.stdout.strip() == "false"
+
+
+def _set_branch_protection(username: str, repo_name: str, branch: str) -> None:
+    """Set branch protection rules."""
+    protection_data = {
+        "required_status_checks": {"strict": True, "contexts": []},
+        "enforce_admins": True,
+        "required_pull_request_reviews": {"required_approving_review_count": 1},
+        "restrictions": None,
+    }
+
+    _run_gh_command(
+        f"api repos/{username}/{repo_name}/branches/{branch}/protection "
+        "-X PUT -H 'Accept: application/vnd.github.v3+json' "
+        f"-f required_status_checks='{protection_data['required_status_checks']}' "
+        f"-f enforce_admins={protection_data['enforce_admins']} "
+        f"-f required_pull_request_reviews='{protection_data['required_pull_request_reviews']}' "
+        f"-f restrictions={protection_data['restrictions']}"
+    )

--- a/ccds/hook_utils/configure_vcs.py
+++ b/ccds/hook_utils/configure_vcs.py
@@ -10,14 +10,16 @@ from typing import Literal
 # ---------------------------------------------------------------------------- #
 
 
-def init_local_git_repo(directory: str | Path, _make_initial_commit: bool = True) -> bool:
+def init_local_git_repo(
+    directory: str | Path, _make_initial_commit: bool = True
+) -> bool:
     """
     Initialize a local git repository without any GitHub integration.
-    
+
     Args:
         directory: Directory where the repository will be created
         _make_initial_commit: Whether to make initial commit (for testing)
-        
+
     Returns:
         bool: True if initialization was successful, False otherwise
     """
@@ -28,23 +30,25 @@ def init_local_git_repo(directory: str | Path, _make_initial_commit: bool = True
         directory = Path(directory)
         if not directory.is_dir():
             raise ValueError(f"Directory '{directory}' does not exist.")
-            
+
         os.chdir(directory)
-        
+
         if not (directory / ".git").is_dir():
             _git("init")
             if _make_initial_commit:
                 _git("add .")
                 _git("commit -m 'Initial commit'")
-            
+
         return True
     except Exception as e:
         print(f"Error during repository initialization: {e}")
         return False
 
+
 def _git(command: str, **kwargs) -> subprocess.CompletedProcess:
     """Run a git command and return the result."""
     return subprocess.run(f"git {command}", shell=True, check=True, **kwargs)
+
 
 def _check_git_cli_installed() -> bool:
     """Check whether git cli is installed"""
@@ -54,9 +58,11 @@ def _check_git_cli_installed() -> bool:
     except subprocess.CalledProcessError:
         return False
 
+
 # ---------------------------------------------------------------------------- #
 #                                 Git + Github                                 #
 # ---------------------------------------------------------------------------- #
+
 
 def configure_github_repo(
     directory: str | Path,

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,11 +2,12 @@ import shutil
 from copy import copy
 from pathlib import Path
 
+from ccds.hook_utils.configure_vcs import configure_github_repo, init_local_git_repo
+
 # https://github.com/cookiecutter/cookiecutter/issues/824
 #   our workaround is to include these utility functions in the CCDS package
 from ccds.hook_utils.custom_config import write_custom_config
 from ccds.hook_utils.dependencies import basic, packages, scaffold, write_dependencies
-from ccds.hook_utils.configure_vcs import configure_github_repo, init_local_git_repo
 
 #
 #  TEMPLATIZED VARIABLES FILLED IN BY COOKIECUTTER
@@ -83,10 +84,7 @@ for generated_path in Path("{{ cookiecutter.module_name }}").iterdir():
 # {% endif %}
 
 # {% if cookiecutter.version_control == "git (local)" %}
-init_local_git_repo(
-    directory=Path.cwd(),
-    _make_initial_commit=False
-)
+init_local_git_repo(directory=Path.cwd(), _make_initial_commit=True)
 # {% elif cookiecutter.version_control == "git (github)" %}
 configure_github_repo(
     directory=Path.cwd(),

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -91,14 +91,10 @@ for generated_path in Path("{{ cookiecutter.module_name }}").iterdir():
 init_local_git_repo(directory=Path.cwd())
 # {% elif cookiecutter.version_control == "git (github private)" %}
 configure_github_repo(
-    directory=Path.cwd(),
-    repo_name="{{ cookiecutter.repo_name }}",
-    visibility="private"
+    directory=Path.cwd(), repo_name="{{ cookiecutter.repo_name }}", visibility="private"
 )
 # {% elif cookiecutter.version_control == "git (github public)" %}
 configure_github_repo(
-    directory=Path.cwd(),
-    repo_name="{{ cookiecutter.repo_name }}",
-    visibility="public"
+    directory=Path.cwd(), repo_name="{{ cookiecutter.repo_name }}", visibility="public"
 )
 # {% endif %}

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -84,7 +84,8 @@ for generated_path in Path("{{ cookiecutter.module_name }}").iterdir():
 
 # {% if cookiecutter.version_control == "git (local)" %}
 init_local_git_repo(
-    directory=Path.cwd()
+    directory=Path.cwd(),
+    _make_initial_commit=False
 )
 # {% elif cookiecutter.version_control == "git (github)" %}
 configure_github_repo(

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -90,6 +90,5 @@ configure_github_repo(
     directory=Path.cwd(),
     repo_name="{{ cookiecutter.repo_name }}",
     protection_type="main_and_dev",
-    no_github=False,
 )
 # {% endif %}

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -6,6 +6,7 @@ from pathlib import Path
 #   our workaround is to include these utility functions in the CCDS package
 from ccds.hook_utils.custom_config import write_custom_config
 from ccds.hook_utils.dependencies import basic, packages, scaffold, write_dependencies
+from ccds.hook_utils.configure_vcs import configure_github_repo
 
 #
 #  TEMPLATIZED VARIABLES FILLED IN BY COOKIECUTTER
@@ -79,4 +80,13 @@ for generated_path in Path("{{ cookiecutter.module_name }}").iterdir():
     elif generated_path.name == "__init__.py":
         # remove any content in __init__.py since it won't be available
         generated_path.write_text("")
+# {% endif %}
+
+# {% if cookiecutter.version_control == "git (github)" %}
+configure_github_repo(
+    directory=Path.cwd(),
+    repo_name="{{ cookiecutter.repo_name }}",
+    protection_type="main_and_dev",
+    no_github=False,
+)
 # {% endif %}

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -83,12 +83,22 @@ for generated_path in Path("{{ cookiecutter.module_name }}").iterdir():
         generated_path.write_text("")
 # {% endif %}
 
+#
+#  VERSION CONTROL
+#
+
 # {% if cookiecutter.version_control == "git (local)" %}
-init_local_git_repo(directory=Path.cwd(), _make_initial_commit=True)
-# {% elif cookiecutter.version_control == "git (github)" %}
+init_local_git_repo(directory=Path.cwd())
+# {% elif cookiecutter.version_control == "git (github private)" %}
 configure_github_repo(
     directory=Path.cwd(),
     repo_name="{{ cookiecutter.repo_name }}",
-    protection_type="main_and_dev",
+    visibility="private"
+)
+# {% elif cookiecutter.version_control == "git (github public)" %}
+configure_github_repo(
+    directory=Path.cwd(),
+    repo_name="{{ cookiecutter.repo_name }}",
+    visibility="public"
 )
 # {% endif %}

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 #   our workaround is to include these utility functions in the CCDS package
 from ccds.hook_utils.custom_config import write_custom_config
 from ccds.hook_utils.dependencies import basic, packages, scaffold, write_dependencies
-from ccds.hook_utils.configure_vcs import configure_github_repo
+from ccds.hook_utils.configure_vcs import configure_github_repo, init_local_git_repo
 
 #
 #  TEMPLATIZED VARIABLES FILLED IN BY COOKIECUTTER
@@ -82,7 +82,11 @@ for generated_path in Path("{{ cookiecutter.module_name }}").iterdir():
         generated_path.write_text("")
 # {% endif %}
 
-# {% if cookiecutter.version_control == "git (github)" %}
+# {% if cookiecutter.version_control == "git (local)" %}
+init_local_git_repo(
+    directory=Path.cwd()
+)
+# {% elif cookiecutter.version_control == "git (github)" %}
 configure_github_repo(
     directory=Path.cwd(),
     repo_name="{{ cookiecutter.repo_name }}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,4 @@ ccds = "ccds.__main__:main"
 
 [tool.pytest.ini_options]
 testpaths = "./tests"
+addopts = "-vv --color=yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ ccds = "ccds.__main__:main"
 "Source Code" = "https://github.com/drivendataorg/cookiecutter-data-science/"
 "Bug Tracker" = "https://github.com/drivendataorg/cookiecutter-data-science/issues"
 "DrivenData" = "https://drivendata.co"
+
+[tool.pytest.ini_options]
+testpaths = "./tests"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ default_args = {
     "module_name": "project_module",
     "author_name": "DrivenData",
     "description": "A test project",
-    "version_control": "none"
+    "version_control": "git (local)"
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def config_generator(fast=False):
         ],
         [("dependency_file", opt) for opt in cookiecutter_json["dependency_file"]],
         [("pydata_packages", opt) for opt in cookiecutter_json["pydata_packages"]],
-        [("version_control", opt) for opt in ("none", "git (local)")]
+        [("version_control", opt) for opt in ("none", "git (local)")],
         # TODO: Tests for "version_control": "git (github)"
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ default_args = {
     "module_name": "project_module",
     "author_name": "DrivenData",
     "description": "A test project",
-    "version_control": "git (local)"
+    "version_control": "git (local)",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ default_args = {
     "module_name": "project_module",
     "author_name": "DrivenData",
     "description": "A test project",
+    "version_control": "none"
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,8 @@ def config_generator(fast=False):
         ],
         [("dependency_file", opt) for opt in cookiecutter_json["dependency_file"]],
         [("pydata_packages", opt) for opt in cookiecutter_json["pydata_packages"]],
+        [("version_control", opt) for opt in ("none", "git (local)")]
+        # TODO: Tests for "version_control": "git (github)"
     )
 
     def _is_valid(config):

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -80,7 +80,11 @@ def verify_folders(root, config):
     if config["docs"] == "mkdocs":
         expected_dirs.add("docs/docs")
 
-    if config["version_control"] in ("git (local)", "git (github public)", "git (github private)"):
+    if config["version_control"] in (
+        "git (local)",
+        "git (github public)",
+        "git (github private)",
+    ):
         # Expected after `git init`
         expected_dirs.update(
             {
@@ -167,7 +171,11 @@ def verify_files(root, config):
 
     expected_files.add(config["dependency_file"])
 
-    if config["version_control"] in ("git (local)", "git (github)"):
+    if config["version_control"] in (
+        "git (local)",
+        "git (github public)",
+        "git (github private)",
+    ):
         # Expected after `git init`
         expected_files.update(
             {

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -80,6 +80,19 @@ def verify_folders(root, config):
 
     if config["docs"] == "mkdocs":
         expected_dirs += ["docs/docs"]
+    
+    if config["version_control"] in ("git (local)", "git (github)"):
+        expected_dirs += [
+            ".git",
+            ".git/hooks",
+            ".git/info",
+            ".git/objects",
+            ".git/objects/info",
+            ".git/objects/pack",
+            ".git/refs",
+            ".git/refs/heads",
+            ".git/refs/tags"
+        ]
 
     expected_dirs = [
         #  (root / d).resolve().relative_to(root) for d in expected_dirs
@@ -137,6 +150,33 @@ def verify_files(root, config):
             "docs/README.md",
             "docs/docs/index.md",
             "docs/docs/getting-started.md",
+        ]
+        
+    if config["version_control"] in ("git (local)", "git (github)"):
+        expected_files += [
+            ".git/config",
+            ".git/description",
+            ".git/FETCH_HEAD",
+            ".git/HEAD",
+            ".git/hooks/applypatch-msg.sample",
+            ".git/hooks/commit-msg.sample",
+            ".git/hooks/fsmonitor-watchman.sample",
+            ".git/hooks/post-update.sample",
+            ".git/hooks/pre-applypatch.sample",
+            ".git/hooks/pre-commit.sample",
+            ".git/hooks/pre-merge-commit.sample",
+            ".git/hooks/pre-push.sample",
+            ".git/hooks/pre-rebase.sample",
+            ".git/hooks/pre-receive.sample",
+            ".git/hooks/prepare-commit-msg.sample",
+            ".git/hooks/push-to-checkout.sample",
+            ".git/hooks/sendemail-validate.sample",
+            ".git/hooks/update.sample",
+            ".git/info/exclude",
+            ".git/objects/info",
+            ".git/objects/pack",
+            ".git/refs/heads",
+            ".git/refs/tags"
         ]
 
     expected_files.append(config["dependency_file"])

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -93,20 +93,18 @@ def verify_folders(root, config):
                 ".git/info",
                 ".git/objects",
                 ".git/refs",
-                ".git/refs/heads",
-                ".git/refs/tags",
             }
         )
         # Expected after initial git commit
-        expected_dirs.update(
-            {
-                ".git/logs",
-                ".git/logs/refs",
-                ".git/logs/refs/heads",
-            }
-        )
+        expected_dirs.update({".git/logs", ".git/logs/refs"})
+        git_patterns = [".git/objects/**/*", ".git/refs/**/*", ".git/logs/refs/**/*"]
         ignored_dirs.update(
-            {d.relative_to(root) for d in root.glob(".git/objects/**/*") if d.is_dir()}
+            {
+                d.relative_to(root)
+                for pattern in git_patterns
+                for d in root.glob(pattern)
+                if d.is_dir()
+            }
         )
 
     expected_dirs = {Path(d) for d in expected_dirs}
@@ -205,12 +203,16 @@ def verify_files(root, config):
                 ".git/COMMIT_EDITMSG",
                 ".git/index",
                 ".git/logs/HEAD",
-                ".git/logs/refs/heads/main",
-                ".git/refs/heads/main",
             }
         )
+        git_patterns = [".git/objects/**/*", ".git/refs/**/*", ".git/logs/refs/**/*"]
         ignored_files.update(
-            {f.relative_to(root) for f in root.glob(".git/objects/**/*") if f.is_file()}
+            {
+                f.relative_to(root)
+                for pattern in git_patterns
+                for f in root.glob(pattern)
+                if f.is_file()
+            }
         )
 
     expected_files = {Path(f) for f in expected_files}

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -80,7 +80,7 @@ def verify_folders(root, config):
     if config["docs"] == "mkdocs":
         expected_dirs.add("docs/docs")
 
-    if config["version_control"] in ("git (local)", "git (github)"):
+    if config["version_control"] in ("git (local)", "git (github public)", "git (github private)"):
         # Expected after `git init`
         expected_dirs.update(
             {

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -7,9 +7,6 @@ from subprocess import PIPE, run
 from conftest import bake_project
 
 BASH_EXECUTABLE = os.getenv("BASH_EXECUTABLE", "bash")
-IGNORE_PATTERNS = [
-    "./.git/objects/**"
-]
 
 
 def _decode_print_stdout_stderr(result):
@@ -60,7 +57,7 @@ def test_baking_configs(config, fast):
 
 def verify_folders(root, config):
     """Tests that expected folders and only expected folders exist."""
-    expected_dirs = [
+    expected_dirs = {
         ".",
         "data",
         "data/external",
@@ -74,19 +71,17 @@ def verify_folders(root, config):
         "reports",
         "reports/figures",
         config["module_name"],
-    ]
+    }
 
     if config["include_code_scaffold"] == "Yes":
-        expected_dirs += [
-            f"{config['module_name']}/modeling",
-        ]
+        expected_dirs.add(f"{config['module_name']}/modeling")
 
     if config["docs"] == "mkdocs":
-        expected_dirs += ["docs/docs"]
+        expected_dirs.add("docs/docs")
     
     if config["version_control"] in ("git (local)", "git (github)"):
         # Expected after `git init`
-        expected_dirs += [
+        expected_dirs.update({
             ".git",
             ".git/hooks",
             ".git/info",
@@ -96,30 +91,26 @@ def verify_folders(root, config):
             ".git/refs",
             ".git/refs/heads",
             ".git/refs/tags",
-        ]
-        # Expected after first git commit
+        })
+        # Expected after initial git commit
         # expected_dirs += [
         #     ".git/logs",
         #     ".git/logs/refs",
         #     ".git/logs/refs/heads",
         # ]
 
-    expected_dirs = [
-        #  (root / d).resolve().relative_to(root) for d in expected_dirs
-        Path(d)
-        for d in expected_dirs
-    ]
+    expected_dirs = {Path(d) for d in expected_dirs}
 
-    existing_dirs = [
+    existing_dirs = {
         d.resolve().relative_to(root) for d in root.glob("**") if d.is_dir()
-    ]
+    }
 
     assert sorted(existing_dirs) == sorted(expected_dirs)
 
 
 def verify_files(root, config):
     """Test that expected files and only expected files exist."""
-    expected_files = [
+    expected_files = {
         "Makefile",
         "README.md",
         "pyproject.toml",
@@ -137,14 +128,14 @@ def verify_files(root, config):
         "reports/figures/.gitkeep",
         "models/.gitkeep",
         f"{config['module_name']}/__init__.py",
-    ]
+    }
 
     # conditional files
     if not config["open_source_license"].startswith("No license"):
-        expected_files.append("LICENSE")
+        expected_files.add("LICENSE")
 
     if config["include_code_scaffold"] == "Yes":
-        expected_files += [
+        expected_files.update({
             f"{config['module_name']}/config.py",
             f"{config['module_name']}/dataset.py",
             f"{config['module_name']}/features.py",
@@ -152,19 +143,19 @@ def verify_files(root, config):
             f"{config['module_name']}/modeling/train.py",
             f"{config['module_name']}/modeling/predict.py",
             f"{config['module_name']}/plots.py",
-        ]
+        })
 
     if config["docs"] == "mkdocs":
-        expected_files += [
+        expected_files.update({
             "docs/mkdocs.yml",
             "docs/README.md",
             "docs/docs/index.md",
             "docs/docs/getting-started.md",
-        ]
+        })
         
     if config["version_control"] in ("git (local)", "git (github)"):
         # Expected after `git init`
-        expected_files += [
+        expected_files.update({
             ".git/config",
             ".git/description",
             ".git/HEAD",
@@ -183,8 +174,8 @@ def verify_files(root, config):
             ".git/hooks/sendemail-validate.sample",
             ".git/hooks/update.sample",
             ".git/info/exclude",
-        ]
-        # Expected after first git commit
+        })
+        # Expected after initial git commit
         # expected_files += [
         #     ".git/COMMIT_EDITMSG",
         #     ".git/FETCH_HEAD",
@@ -194,18 +185,27 @@ def verify_files(root, config):
         #     ".git/refs/heads/main",
         # ]
 
-    expected_files.append(config["dependency_file"])
+    expected_files.add(config["dependency_file"])
+    
+    ignored_files = set()
+    
+    if config["version_control"] in ("git (local)", "git (github)"):
+        ignored_files.update({
+            f.relative_to(root) 
+            for f in root.glob(".git/objects/*") 
+            if f.is_file()
+        })
 
-    expected_files = [Path(f) for f in expected_files]
+    expected_files = {Path(f) for f in expected_files}
 
-    existing_files = [f.relative_to(root) for f in root.glob("**/*") if f.is_file()]
+    existing_files = {f.relative_to(root) for f in root.glob("**/*") if f.is_file()}
 
-    assert sorted(existing_files) == sorted(expected_files)
+    assert sorted(existing_files - ignored_files) == sorted(expected_files)
     
     # Ignore files where curlies may exist but aren't unrendered jinja tags
-    ignore_curly_files = [
+    ignore_curly_files = {
         ".git/hooks/fsmonitor-watchman.sample"
-    ]
+    }
 
     assert all(
         no_curlies(root / f)


### PR DESCRIPTION
## Overview

This PR adds extremely basic + minimalist functionality to initialize and optionally upload a git repository to a public or private GitHub using the `git` and `gh` command line tools in a hook. If these tools are not found, the user is informed that they need to be downloaded for this feature to work.

![GatScreen_2024-12-28_00 35 32@2x](https://github.com/user-attachments/assets/7ba202cc-2f57-431d-ab8d-8544f77a742d)

![Made with VHS](https://vhs.charm.sh/vhs-2sr8HJyZrjcOuh5songJ1B.gif)

I've read discussion #380 and while this PR is for Git/GitHub (since I used those tools), this could be extended to other version control systems or repository hosts. The need for the external CLI dependencies could be made internal by using some existing PyPi package included in the CCDS distribution.

## Tests
- Added tests for `git (local)` which simply checks whether the expected files/directories exist.
- Set `none` and `git (local)` to be included in the test suite by default.
- NO TESTS for `git (github public)` or `git (github private)`. However these have been tested manually.

## Misc
- Updated `tests/test_creation` to use sets instead of lists. This keeps the syntax simple yet allows easily ignoring files by subtracting the ignored files selected via glob from the existing files. This is helpful for git tracking which uses hashes for dirs/file names
- Added a few pytest options to `pyproject.toml` to get it to play better with VSCode's built-in testing ui.